### PR TITLE
midiChan documentation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -481,13 +481,18 @@ class FlMidiMsg:
 
     @property
     def midiChan(self) -> int:
-        """MIDI chan
-
-        ### HELP WANTED:
-        * What is this?
-
-        * No, it's not a channel. It always seems to be zero, regardless of the
-          channel of the event.
+        """The MIDI channel
+        
+        Some MIDI controllers allow you to set the channel for certain actions.
+        For example, in the Novation Components software, you can set the 
+        channel for the Novation Launchkey Mini MK3's drum pads.
+        
+        In FL Studio, these channels are used in the MIDI settings for features
+        like:
+        * Omni preview
+        * Song marker jump
+        * Performance mode
+        * Generator muting
         """
         return self.__midi_chan
 

--- a/__init__.py
+++ b/__init__.py
@@ -493,6 +493,9 @@ class FlMidiMsg:
         * Song marker jump
         * Performance mode
         * Generator muting
+        
+        Note that here, midiChan starts at 0, whereas in FL Studio the channels
+        start at 1 (so they are off by one).
         """
         return self.__midi_chan
 


### PR DESCRIPTION
Hey, I've been writing a script for my Novation Launchkey Mini MK3 with the help of your module here. I noticed that you hadn't figured out what midiChan is used for. I've found out that it's related to the MIDI channel—here's what I've written for the documentation:

```
Some MIDI controllers allow you to set the channel for certain actions.
For example, in the Novation Components software, you can set the 
channel for the Novation Launchkey Mini MK3's drum pads.
        
In FL Studio, these channels are used in the MIDI settings for features
like:
* Omni preview
* Song marker jump
* Performance mode
* Generator muting
        
Note that here, midiChan starts at 0, whereas in FL Studio the channels
start at 1 (so they are off by one).
```

Hopefully this is helpful!